### PR TITLE
Bump supported MassTransit versions to latest/7.1.5

### DIFF
--- a/MassTransit.ActivityTracing/MassTransit.ActivityTracing.csproj
+++ b/MassTransit.ActivityTracing/MassTransit.ActivityTracing.csproj
@@ -12,11 +12,11 @@
     <NeutralLanguage>en</NeutralLanguage>
     <Description>MassTransit extension to configure distributed trace propagation between asynchronous message broker operations.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>0.1</Version>
+    <Version>0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MassTransit" Version="[6.0.1,7.0.0)" />
+    <PackageReference Include="MassTransit" Version="[6.0.1,7.1.5)" />
   </ItemGroup>
 
 </Project>

--- a/MassTransit.ActivityTracing/MassTransit.ActivityTracing.csproj
+++ b/MassTransit.ActivityTracing/MassTransit.ActivityTracing.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MassTransit" Version="[6.0.1,7.1.5)" />
+    <PackageReference Include="MassTransit" Version="[6.0.1,7.1.5]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Would like to use the latest version of MassTransit with this package.

As far as I can see, this should not cause any issues.